### PR TITLE
removed some contradictory code

### DIFF
--- a/common/main.c
+++ b/common/main.c
@@ -626,27 +626,6 @@ static char* hist_next(void)
 	return (ret);
 }
 
-#ifndef CONFIG_CMDLINE_EDITING
-static void cread_print_hist_list(void)
-{
-	int i;
-	unsigned long n;
-
-	n = hist_num - hist_max;
-
-	i = hist_add_idx + 1;
-	while (1) {
-		if (i > hist_max)
-			i = 0;
-		if (i == hist_add_idx)
-			break;
-		printf("%s\n", hist_list[i]);
-		n++;
-		i++;
-	}
-}
-#endif /* CONFIG_CMDLINE_EDITING */
-
 #define BEGINNING_OF_LINE() {			\
 	while (num) {				\
 		getcmd_putch(CTL_BACKSPACE);	\

--- a/net/bootp.c
+++ b/net/bootp.c
@@ -480,17 +480,6 @@ static int BootpExtended (u8 * e)
 	*e++ = 83;
 	*e++ = 99;
 
-#if defined(CONFIG_CMD_DHCP)
-	*e++ = 53;		/* DHCP Message Type */
-	*e++ = 1;
-	*e++ = DHCP_DISCOVER;
-
-	*e++ = 57;		/* Maximum DHCP Message Size */
-	*e++ = 2;
-	*e++ = (576 - 312 + OPT_SIZE) >> 16;
-	*e++ = (576 - 312 + OPT_SIZE) & 0xff;
-#endif
-
 #if defined(CONFIG_BOOTP_SUBNETMASK)
 	*e++ = 1;		/* Subnet mask request */
 	*e++ = 4;


### PR DESCRIPTION
in common/main.c, the cread_print_hist_list function is defined inside a #ifndef CONFIG_CMDLINE_EDITING defination. However, this code snippest is inside a bigger #ifdef CONFIG_CMDLINE_EDITING which begin its defination at line and ends it defination at line 916. So the function presence condition will never be met.

in net/bootp.c, the situation is similar, the code code snippest I have deleted precense condition will never be met due to the #ifndef CONFIG_CMD_DHCP(line 356 and 'else' in line 470) and the block itself presence condition #ifdef CONFIG_CMD_DHCP. 